### PR TITLE
fix: catalog pagination truncation and ZIM magic bytes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,12 @@ src/offline_search/
 ├── config.py          # Centralised settings (pydantic-settings, .env support)
 ├── search_engine.py   # Core FTS5 search: tokeniser, BM25, ranking, filtering
 ├── formatter.py       # Result formatting (standard + compact output modes)
-├── kiwix.py           # Kiwix-serve lifecycle + page fetching
+├── kiwix.py           # Kiwix-serve lifecycle (start/stop/restart) + page fetching
 ├── indexer.py         # ZIM → SQLite indexer (CLI: offline-search-index)
 ├── mcp.py             # Unified MCP server — auto-detects local/remote mode
-└── server.py          # FastAPI HTTP search API + content management
+├── server.py          # FastAPI HTTP API + content management + ZIM upload endpoints
+├── updater.py         # Server-side ZIM management — zero-downtime ingest pipeline
+└── catalog.py         # Online Kiwix catalog client — check/download/push updates
 
 .claude/agents/
 └── offline-search-agent.md  # Haiku sub-agent for token-efficient search
@@ -53,6 +55,19 @@ offline-search-server
 
 # Start MCP in explicit remote mode
 OFFLINE_SEARCH_REMOTE_HOST=192.168.1.50 offline-search-mcp
+
+# ZIM update management (server-side)
+offline-search-update ingest path/to/new.zim     # Zero-downtime ingest
+offline-search-update list                        # List installed ZIMs
+offline-search-update remove filename.zim         # Remove a ZIM
+offline-search-update manifest                    # Export JSON manifest
+
+# Catalog client (online machine)
+offline-search-catalog check --manifest m.json    # Check for updates
+offline-search-catalog search python              # Search the Kiwix catalog
+offline-search-catalog download devdocs_python    # Download a ZIM
+offline-search-catalog update --push http://srv:8082 --api-key $KEY  # Download & push
+offline-search-catalog watch --auto-download --interval 24           # Daemon mode
 ```
 
 ## MCP Tools Provided
@@ -74,6 +89,12 @@ All settings can be overridden via environment variables prefixed with `OFFLINE_
 | `OFFLINE_SEARCH_SERVER_PORT` | `8082` | Port for the HTTP API |
 | `OFFLINE_SEARCH_REMOTE_HOST` | `127.0.0.1` | Server IP for remote mode |
 | `OFFLINE_SEARCH_COMPACT_FORMAT` | `false` | Use compact output for MCP tools (reduces tokens) |
+| `OFFLINE_SEARCH_ZIM_DIR` | `{base_dir}/zims` | ZIM file storage directory |
+| `OFFLINE_SEARCH_KIWIX_MANAGE` | auto-detect | Path to kiwix-manage binary |
+| `OFFLINE_SEARCH_UPLOAD_MAX_SIZE_GB` | `20` | Max ZIM upload size |
+| `OFFLINE_SEARCH_CATALOG_URL` | `https://library.kiwix.org/catalog/search` | OPDS catalog endpoint |
+| `OFFLINE_SEARCH_MANIFEST_PATH` | `{base_dir}/data/zim_manifest.json` | Manifest file path |
+| `OFFLINE_SEARCH_API_KEY` | `""` (empty = ZIM endpoints disabled) | API key for `/zim/*` mutation endpoints |
 
 Or place them in a `.env` file at the project root.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ graph LR
 - **Dual tools** — `google_search` for search + `visit_page` to read full content
 - **Smart ranking** — BM25 with title boosting, synonym expansion, prefix matching, and non-English demotion
 - **Distributed ready** — run the heavy ZIM server centrally, connect lightweight clients over the network
+- **Zero-downtime ZIM updates** — ingest new ZIM versions while old content continues serving; atomic swap when done
+- **Catalog client** — check the Kiwix OPDS catalog for updates, download with SHA-256 verification, push to server or sneakernet
+- **Secure ZIM management** — API key auth on mutation endpoints, magic byte validation, configurable size limits
 - **Content management API** — index custom HTML pages, crawl internal sites, manage the index via REST
 - **Extensible** — inject content from Confluence, Artifactory, or any other source
 - **Token-efficient** — Haiku sub-agent summarises raw results before returning to main model; optional compact format reduces MCP output tokens
@@ -162,10 +165,12 @@ src/offline_search/
 ├── config.py          # Centralised settings (env vars, .env, defaults)
 ├── search_engine.py   # Core FTS5 search: tokeniser, BM25, ranking, filtering
 ├── formatter.py       # Result formatting (standard + compact output modes)
-├── kiwix.py           # Kiwix-serve lifecycle + page fetching → Markdown
+├── kiwix.py           # Kiwix-serve lifecycle (start/stop/restart) + page fetching
 ├── indexer.py         # ZIM → SQLite indexer (CLI: offline-search-index)
 ├── mcp.py             # Unified MCP server — auto-detects local/remote mode
-└── server.py          # FastAPI HTTP API + content management endpoints
+├── server.py          # FastAPI HTTP API + content management + ZIM upload
+├── updater.py         # Server-side ZIM management — zero-downtime ingest pipeline
+└── catalog.py         # Online Kiwix catalog client — check/download/push updates
 
 .claude/agents/
 └── offline-search-agent.md  # Haiku sub-agent for token-efficient search
@@ -191,14 +196,21 @@ scripts/               # Installation helpers (skill or MCP)
 
 When running the server (`offline-search-server`):
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/search?q=...&limit=10&zim=...` | Full-text search |
-| `GET` | `/health` | Health check + index stats |
-| `GET` | `/stats` | Detailed index statistics |
-| `POST` | `/index/page` | Index a single HTML/text page |
-| `POST` | `/index/crawl` | Crawl and index a website |
-| `DELETE` | `/index?url=...` | Remove a document by URL |
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `GET` | `/search?q=...&limit=10&zim=...` | No | Full-text search |
+| `GET` | `/health` | No | Health check + index stats |
+| `GET` | `/stats` | No | Detailed index statistics |
+| `POST` | `/index/page` | No | Index a single HTML/text page |
+| `POST` | `/index/crawl` | No | Crawl and index a website |
+| `DELETE` | `/index?url=...` | No | Remove a document by URL |
+| `GET` | `/zim/list` | No | List installed ZIMs with versions |
+| `GET` | `/zim/manifest` | No | Export JSON manifest of installed ZIMs |
+| `POST` | `/zim/upload` | Yes | Upload a ZIM file (validates + zero-downtime ingest) |
+| `POST` | `/zim/ingest` | Yes | Ingest a ZIM file already on disk |
+| `DELETE` | `/zim/{filename}` | Yes | Remove a ZIM from library + index + disk |
+
+**Auth**: Endpoints marked "Yes" require `Authorization: Bearer <key>` header. Set `OFFLINE_SEARCH_API_KEY` to enable; if unset, mutation endpoints return 403 (fail-closed).
 
 ## Configuration
 
@@ -212,8 +224,63 @@ All settings support environment variable overrides (prefix: `OFFLINE_SEARCH_`):
 | `OFFLINE_SEARCH_SERVER_PORT` | `8082` | HTTP API port |
 | `OFFLINE_SEARCH_REMOTE_HOST` | `127.0.0.1` | Server IP for remote mode |
 | `OFFLINE_SEARCH_COMPACT_FORMAT` | `false` | Use compact output for MCP tools (reduces tokens) |
+| `OFFLINE_SEARCH_ZIM_DIR` | `{base_dir}/zims` | ZIM file storage directory |
+| `OFFLINE_SEARCH_KIWIX_MANAGE` | auto-detect | Path to kiwix-manage binary |
+| `OFFLINE_SEARCH_UPLOAD_MAX_SIZE_GB` | `20` | Max ZIM upload size |
+| `OFFLINE_SEARCH_CATALOG_URL` | `https://library.kiwix.org/catalog/search` | Kiwix OPDS catalog endpoint |
+| `OFFLINE_SEARCH_MANIFEST_PATH` | `{base_dir}/data/zim_manifest.json` | Manifest file path |
+| `OFFLINE_SEARCH_API_KEY` | `""` (empty = disabled) | API key for `/zim/*` mutation endpoints |
 
 Or create a `.env` file at the project root.
+
+## ZIM Update Management
+
+Offline Search provides a complete pipeline for keeping ZIM files up to date, from fully manual (sneakernet) to fully automated.
+
+### Zero-Downtime Updates
+
+When ingesting a new version of a ZIM, the old content **continues serving searches** while the new version is being indexed. Once indexing completes, old rows are atomically removed — no downtime window.
+
+```bash
+# Server-side: ingest a new ZIM (auto-detects and replaces older version)
+offline-search-update ingest devdocs_en_python_2026-03.zim
+
+# List installed ZIMs
+offline-search-update list
+
+# Export a manifest for the catalog client
+offline-search-update manifest --output /usb/manifest.json
+```
+
+### Catalog Client
+
+The catalog client runs on an **internet-connected machine** to check for updates:
+
+```bash
+# Check what's available vs. what's installed
+offline-search-catalog check --manifest /usb/manifest.json
+
+# Search the Kiwix catalog
+offline-search-catalog search python
+
+# Download a specific ZIM
+offline-search-catalog download devdocs_en_python --dest /usb/
+
+# Download all updates and push to the air-gapped server
+offline-search-catalog update --push http://server:8082 --api-key $KEY
+
+# Watch mode: check every 24h, auto-download, notify via Slack
+offline-search-catalog watch --auto-download --auto-push http://srv:8082 \
+    --api-key $KEY --notify-command "curl -X POST slack.webhook"
+```
+
+### Update Strategies
+
+| Strategy | Setup | Security |
+|----------|-------|----------|
+| **Sneakernet** | `catalog download` → USB → `update ingest` | Highest — no network path |
+| **Semi-automated** | `watch --auto-download --notify-command send-email.sh` | Human reviews before transfer |
+| **Fully automated** | `watch --auto-download --auto-push` | Convenient; API key required |
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "fastapi>=0.110.0",
     "uvicorn>=0.29.0",
     "markdownify>=0.14.1",
+    "python-multipart>=0.0.9",
 ]
 
 [project.urls]
@@ -54,6 +55,8 @@ dev = [
 offline-search-mcp     = "offline_search.mcp:main"
 offline-search-server  = "offline_search.server:main"
 offline-search-index   = "offline_search.indexer:main"
+offline-search-update  = "offline_search.updater:main"
+offline-search-catalog = "offline_search.catalog:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/offline_search"]

--- a/src/offline_search/catalog.py
+++ b/src/offline_search/catalog.py
@@ -175,6 +175,33 @@ def compare_versions(
     return updates
 
 
+def check_updates_for_installed(
+    installed: list[ZimInfo],
+    *,
+    catalog_url: str | None = None,
+    verify_tls: bool = True,
+) -> list[UpdateAvailable]:
+    """Query the catalog per installed ZIM and return available updates.
+
+    Instead of a single parameterless fetch (which only returns the first page
+    of ~50 results), this queries the catalog individually for each installed
+    ZIM's base_name, ensuring updates are found even if they've fallen off
+    the first page.
+    """
+    updates: list[UpdateAvailable] = []
+    for zim in installed:
+        entries = fetch_catalog(
+            query=zim.base_name,
+            catalog_url=catalog_url,
+            verify_tls=verify_tls,
+        )
+        for entry in entries:
+            if entry.name == zim.base_name and entry.version > zim.version:
+                updates.append(UpdateAvailable(installed=zim, available=entry))
+                break
+    return updates
+
+
 # ---------------------------------------------------------------------------
 # Download & integrity
 # ---------------------------------------------------------------------------
@@ -333,9 +360,12 @@ def _watch_tick(config: WatchConfig, manifest_path: Path) -> None:
     else:
         installed = []
 
-    # Fetch catalog
-    catalog = fetch_catalog(catalog_url=config.catalog_url, verify_tls=config.verify_tls)
-    updates = compare_versions(installed, catalog)
+    # Fetch catalog per installed ZIM (avoids first-page truncation)
+    updates = check_updates_for_installed(
+        installed,
+        catalog_url=config.catalog_url,
+        verify_tls=config.verify_tls,
+    )
 
     if not updates:
         logger.info("No updates available.")
@@ -439,8 +469,7 @@ def main() -> None:
             installed = get_installed_zims()
 
         catalog_url = getattr(args, "catalog_url", None)
-        catalog = fetch_catalog(catalog_url=catalog_url)
-        updates = compare_versions(installed, catalog)
+        updates = check_updates_for_installed(installed, catalog_url=catalog_url)
 
         if not updates:
             print("All ZIMs are up to date.")
@@ -480,8 +509,7 @@ def main() -> None:
             installed = get_installed_zims()
 
         catalog_url = getattr(args, "catalog_url", None)
-        catalog = fetch_catalog(catalog_url=catalog_url)
-        updates = compare_versions(installed, catalog)
+        updates = check_updates_for_installed(installed, catalog_url=catalog_url)
 
         if not updates:
             print("All ZIMs are up to date.")

--- a/src/offline_search/catalog.py
+++ b/src/offline_search/catalog.py
@@ -1,0 +1,525 @@
+"""Online Kiwix catalog client — check for updates, download, and push ZIMs.
+
+Supports one-shot CLI commands and a configurable watch/daemon mode.
+
+CLI: ``offline-search-catalog``
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from xml.etree import ElementTree
+
+import httpx
+
+from .config import settings
+from .updater import ZimInfo, parse_zim_version
+
+logger = logging.getLogger(__name__)
+
+# OPDS Atom namespace
+_ATOM_NS = "http://www.w3.org/2005/Atom"
+_OPDS_NS = "urn:opds:catalog:2016"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CatalogEntry:
+    name: str
+    version: str
+    title: str
+    description: str
+    url: str
+    size: int
+    language: str
+    sha256: str
+
+
+@dataclass
+class UpdateAvailable:
+    installed: ZimInfo
+    available: CatalogEntry
+
+
+@dataclass
+class WatchConfig:
+    interval_hours: float = 24
+    auto_download: bool = False
+    auto_push: bool = False
+    push_url: str | None = None
+    push_api_key: str | None = None
+    dest_dir: Path = field(default_factory=lambda: Path("./downloads"))
+    notify_command: str | None = None
+    catalog_url: str = "https://library.kiwix.org/catalog/search"
+    verify_tls: bool = True
+    dry_run: bool = False
+
+
+# ---------------------------------------------------------------------------
+# OPDS catalog parsing
+# ---------------------------------------------------------------------------
+
+def fetch_catalog(
+    query: str | None = None,
+    *,
+    catalog_url: str | None = None,
+    verify_tls: bool = True,
+    timeout: float = 30.0,
+) -> list[CatalogEntry]:
+    """Fetch and parse the Kiwix OPDS catalog. Returns a list of entries."""
+    base_url = catalog_url or settings.catalog_url
+    params = {}
+    if query:
+        params["q"] = query
+
+    with httpx.Client(verify=verify_tls, timeout=timeout) as client:
+        resp = client.get(base_url, params=params)
+        resp.raise_for_status()
+
+    return _parse_opds_feed(resp.text)
+
+
+def _parse_opds_feed(xml_text: str) -> list[CatalogEntry]:
+    """Parse an OPDS Atom feed into CatalogEntry objects."""
+    root = ElementTree.fromstring(xml_text)
+    entries: list[CatalogEntry] = []
+
+    for entry_el in root.findall(f"{{{_ATOM_NS}}}entry"):
+        title = _atom_text(entry_el, "title") or ""
+        summary = _atom_text(entry_el, "summary") or ""
+        language = _atom_text(entry_el, f"{{{_OPDS_NS}}}language") or _atom_text(entry_el, "language") or ""
+
+        # Find the ZIM download link
+        url = ""
+        size = 0
+        sha256 = ""
+        for link in entry_el.findall(f"{{{_ATOM_NS}}}link"):
+            link_type = link.get("type", "")
+            if "application/x-zim" in link_type or link.get("href", "").endswith(".zim"):
+                url = link.get("href", "")
+                try:
+                    size = int(link.get("length", "0"))
+                except ValueError:
+                    size = 0
+                break
+
+        # Extract name/version from the URL filename or entry ID
+        name = ""
+        version = ""
+        entry_id = _atom_text(entry_el, "id") or ""
+        if url:
+            filename_stem = Path(url.split("?")[0]).stem
+            try:
+                name, version = parse_zim_version(filename_stem)
+            except ValueError:
+                name = filename_stem
+                version = ""
+
+        # Look for checksum in various places
+        for link in entry_el.findall(f"{{{_ATOM_NS}}}link"):
+            if link.get("rel") == "http://opds-spec.org/acquisition" or "checksum" in link.get("rel", ""):
+                sha256 = link.get("sha256", "")
+
+        entries.append(CatalogEntry(
+            name=name,
+            version=version,
+            title=title,
+            description=summary,
+            url=url,
+            size=size,
+            language=language,
+            sha256=sha256,
+        ))
+
+    return entries
+
+
+def _atom_text(el: ElementTree.Element, tag: str) -> str | None:
+    """Get text content of a child element."""
+    # Try with namespace first, then without
+    child = el.find(f"{{{_ATOM_NS}}}{tag}")
+    if child is None:
+        child = el.find(tag)
+    return child.text if child is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Version comparison
+# ---------------------------------------------------------------------------
+
+def compare_versions(
+    installed: list[ZimInfo],
+    catalog: list[CatalogEntry],
+) -> list[UpdateAvailable]:
+    """Find catalog entries that are newer than installed versions."""
+    installed_map = {z.base_name: z for z in installed}
+    updates: list[UpdateAvailable] = []
+
+    for entry in catalog:
+        if not entry.name or not entry.version:
+            continue
+        if entry.name in installed_map:
+            current = installed_map[entry.name]
+            if entry.version > current.version:
+                updates.append(UpdateAvailable(installed=current, available=entry))
+
+    return updates
+
+
+# ---------------------------------------------------------------------------
+# Download & integrity
+# ---------------------------------------------------------------------------
+
+def verify_checksum(path: Path, expected_sha256: str) -> bool:
+    """Verify SHA-256 checksum of a file."""
+    if not expected_sha256:
+        logger.warning("No checksum provided for %s, skipping verification", path.name)
+        return True
+
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+
+    actual = h.hexdigest()
+    if actual != expected_sha256.lower():
+        logger.error(
+            "Checksum mismatch for %s: expected %s, got %s",
+            path.name, expected_sha256, actual,
+        )
+        return False
+    return True
+
+
+def download_zim(
+    entry: CatalogEntry,
+    dest_dir: Path,
+    *,
+    progress_cb: object | None = None,
+    verify_tls: bool = True,
+    verify_checksum_flag: bool = True,
+    timeout: float = 300.0,
+) -> Path:
+    """Stream-download a ZIM file with optional SHA-256 verification.
+
+    Returns the path to the downloaded file.
+    Raises ``ValueError`` on checksum mismatch, ``httpx.HTTPError`` on network failure.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    filename = entry.url.split("/")[-1].split("?")[0]
+    if not filename.endswith(".zim"):
+        filename = f"{entry.name}_{entry.version}.zim"
+    dest = dest_dir / filename
+
+    logger.info("Downloading %s → %s", entry.url, dest)
+
+    with httpx.Client(verify=verify_tls, timeout=timeout, follow_redirects=True) as client:
+        with client.stream("GET", entry.url) as resp:
+            resp.raise_for_status()
+            with open(dest, "wb") as f:
+                for chunk in resp.iter_bytes(chunk_size=65536):
+                    f.write(chunk)
+
+    if verify_checksum_flag and entry.sha256:
+        if not verify_checksum(dest, entry.sha256):
+            dest.unlink(missing_ok=True)
+            raise ValueError(f"Checksum verification failed for {filename}")
+
+    logger.info("Download complete: %s", dest)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Push to server
+# ---------------------------------------------------------------------------
+
+def push_to_server(
+    zim_path: Path,
+    server_url: str,
+    *,
+    api_key: str | None = None,
+    verify_tls: bool = True,
+    timeout: float = 600.0,
+) -> bool:
+    """Upload a ZIM file to a remote offline-search server."""
+    upload_url = f"{server_url.rstrip('/')}/zim/upload"
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    logger.info("Pushing %s → %s", zim_path.name, upload_url)
+
+    with httpx.Client(verify=verify_tls, timeout=timeout) as client:
+        with open(zim_path, "rb") as f:
+            resp = client.post(
+                upload_url,
+                files={"file": (zim_path.name, f, "application/octet-stream")},
+                headers=headers,
+            )
+
+    if resp.status_code != 200:
+        logger.error("Push failed (%d): %s", resp.status_code, resp.text)
+        return False
+
+    logger.info("Push successful: %s", resp.json())
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Manifest I/O
+# ---------------------------------------------------------------------------
+
+def export_manifest(installed: list[ZimInfo], path: Path) -> None:
+    """Write a JSON manifest of installed ZIMs."""
+    data = [
+        {"base_name": z.base_name, "version": z.version, "filename": z.filename}
+        for z in installed
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    logger.info("Manifest written to %s", path)
+
+
+def load_manifest(path: Path) -> list[ZimInfo]:
+    """Load a JSON manifest into ZimInfo objects."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return [
+        ZimInfo(
+            base_name=e["base_name"],
+            version=e["version"],
+            filename=e.get("filename", ""),
+            zim_path=Path(e.get("filename", "")),
+        )
+        for e in data
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Watch mode
+# ---------------------------------------------------------------------------
+
+def watch(config: WatchConfig, manifest_path: Path) -> None:
+    """Long-running loop: check for updates, download, and optionally push."""
+    logger.info(
+        "Watch mode started (interval=%sh, dry_run=%s)",
+        config.interval_hours, config.dry_run,
+    )
+
+    while True:
+        try:
+            _watch_tick(config, manifest_path)
+        except Exception:
+            logger.exception("Watch tick failed")
+
+        interval_seconds = config.interval_hours * 3600
+        logger.info("Sleeping %.0f seconds until next check …", interval_seconds)
+        time.sleep(interval_seconds)
+
+
+def _watch_tick(config: WatchConfig, manifest_path: Path) -> None:
+    """Single iteration of the watch loop."""
+    # Load current state
+    if manifest_path.exists():
+        installed = load_manifest(manifest_path)
+    else:
+        installed = []
+
+    # Fetch catalog
+    catalog = fetch_catalog(catalog_url=config.catalog_url, verify_tls=config.verify_tls)
+    updates = compare_versions(installed, catalog)
+
+    if not updates:
+        logger.info("No updates available.")
+        return
+
+    logger.info("Found %d update(s):", len(updates))
+    for u in updates:
+        logger.info(
+            "  %s: %s → %s", u.installed.base_name, u.installed.version, u.available.version,
+        )
+
+    if config.dry_run:
+        logger.info("[DRY RUN] Would download %d update(s)", len(updates))
+        return
+
+    if not config.auto_download:
+        logger.info("Auto-download disabled. Run 'catalog download' manually.")
+        return
+
+    for u in updates:
+        try:
+            dest = download_zim(
+                u.available,
+                config.dest_dir,
+                verify_tls=config.verify_tls,
+            )
+        except Exception:
+            logger.exception("Failed to download %s", u.available.name)
+            continue
+
+        if config.auto_push and config.push_url:
+            push_to_server(dest, config.push_url, api_key=config.push_api_key, verify_tls=config.verify_tls)
+
+    # Run notify command if configured
+    if config.notify_command:
+        import subprocess
+        try:
+            subprocess.run(config.notify_command, shell=True, check=False, timeout=30)
+        except Exception:
+            logger.exception("Notify command failed")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """CLI: ``offline-search-catalog``"""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    parser = argparse.ArgumentParser(description="Kiwix catalog client for offline-search.")
+    sub = parser.add_subparsers(dest="command")
+
+    # check
+    p_check = sub.add_parser("check", help="Check for available updates")
+    p_check.add_argument("--manifest", type=Path, help="Path to manifest file")
+    p_check.add_argument("--server", type=str, help="Server URL to query manifest from")
+    p_check.add_argument("--catalog-url", type=str, help="Override catalog URL")
+
+    # search
+    p_search = sub.add_parser("search", help="Search the Kiwix catalog")
+    p_search.add_argument("query", help="Search query")
+    p_search.add_argument("--catalog-url", type=str, help="Override catalog URL")
+
+    # download
+    p_download = sub.add_parser("download", help="Download a ZIM from the catalog")
+    p_download.add_argument("name", help="ZIM name to download")
+    p_download.add_argument("--dest", type=Path, default=Path("./downloads"), help="Download directory")
+    p_download.add_argument("--no-verify", action="store_true", help="Skip checksum verification")
+    p_download.add_argument("--catalog-url", type=str, help="Override catalog URL")
+
+    # update
+    p_update = sub.add_parser("update", help="Download all available updates")
+    p_update.add_argument("--manifest", type=Path, help="Path to manifest file")
+    p_update.add_argument("--dest", type=Path, default=Path("./downloads"), help="Download directory")
+    p_update.add_argument("--push", type=str, help="Push to server URL after download")
+    p_update.add_argument("--api-key", type=str, help="API key for push")
+    p_update.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    p_update.add_argument("--catalog-url", type=str, help="Override catalog URL")
+
+    # watch
+    p_watch = sub.add_parser("watch", help="Watch for updates (daemon mode)")
+    p_watch.add_argument("--config", type=Path, help="JSON config file for watch mode")
+    p_watch.add_argument("--interval", type=float, default=24, help="Check interval in hours")
+    p_watch.add_argument("--auto-download", action="store_true")
+    p_watch.add_argument("--auto-push", type=str, help="Auto-push to server URL")
+    p_watch.add_argument("--api-key", type=str)
+    p_watch.add_argument("--notify-command", type=str)
+    p_watch.add_argument("--manifest", type=Path)
+    p_watch.add_argument("--dry-run", action="store_true")
+    p_watch.add_argument("--catalog-url", type=str)
+
+    args = parser.parse_args()
+
+    if args.command == "check":
+        manifest_path = args.manifest or settings.manifest_path
+        if manifest_path.exists():
+            installed = load_manifest(manifest_path)
+        else:
+            from .updater import get_installed_zims
+            installed = get_installed_zims()
+
+        catalog_url = getattr(args, "catalog_url", None)
+        catalog = fetch_catalog(catalog_url=catalog_url)
+        updates = compare_versions(installed, catalog)
+
+        if not updates:
+            print("All ZIMs are up to date.")
+        else:
+            print(f"Found {len(updates)} update(s):")
+            for u in updates:
+                print(f"  {u.installed.base_name}: {u.installed.version} → {u.available.version}")
+
+    elif args.command == "search":
+        catalog_url = getattr(args, "catalog_url", None)
+        entries = fetch_catalog(query=args.query, catalog_url=catalog_url)
+        if not entries:
+            print("No results found.")
+        else:
+            for e in entries:
+                print(f"  {e.name} ({e.version}) — {e.title}")
+                if e.description:
+                    print(f"    {e.description[:100]}")
+
+    elif args.command == "download":
+        catalog_url = getattr(args, "catalog_url", None)
+        entries = fetch_catalog(query=args.name, catalog_url=catalog_url)
+        match = next((e for e in entries if e.name == args.name), None)
+        if not match:
+            match = entries[0] if entries else None
+        if not match:
+            logger.error("No catalog entry found for %s", args.name)
+            return
+        download_zim(match, args.dest, verify_checksum_flag=not args.no_verify)
+
+    elif args.command == "update":
+        manifest_path = args.manifest or settings.manifest_path
+        if manifest_path.exists():
+            installed = load_manifest(manifest_path)
+        else:
+            from .updater import get_installed_zims
+            installed = get_installed_zims()
+
+        catalog_url = getattr(args, "catalog_url", None)
+        catalog = fetch_catalog(catalog_url=catalog_url)
+        updates = compare_versions(installed, catalog)
+
+        if not updates:
+            print("All ZIMs are up to date.")
+            return
+
+        if args.dry_run:
+            print(f"[DRY RUN] Would download {len(updates)} update(s):")
+            for u in updates:
+                print(f"  {u.installed.base_name}: {u.installed.version} → {u.available.version}")
+            return
+
+        for u in updates:
+            try:
+                dest = download_zim(u.available, args.dest)
+            except Exception:
+                logger.exception("Failed to download %s", u.available.name)
+                continue
+
+            if args.push:
+                push_to_server(dest, args.push, api_key=args.api_key)
+
+    elif args.command == "watch":
+        manifest_path = args.manifest or settings.manifest_path
+        config = WatchConfig(
+            interval_hours=args.interval,
+            auto_download=args.auto_download,
+            auto_push=bool(args.auto_push),
+            push_url=args.auto_push,
+            push_api_key=args.api_key,
+            notify_command=args.notify_command,
+            dry_run=args.dry_run,
+            catalog_url=args.catalog_url or settings.catalog_url,
+        )
+        watch(config, manifest_path)
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/offline_search/config.py
+++ b/src/offline_search/config.py
@@ -36,6 +36,26 @@ def _detect_base_dir() -> Path:
     return Path.cwd()
 
 
+def _detect_kiwix_manage() -> str:
+    """Best-effort auto-detection of the kiwix-manage binary."""
+    is_windows = platform.system() == "Windows"
+    bin_name = "kiwix-manage.exe" if is_windows else "kiwix-manage"
+
+    base = _detect_base_dir()
+    local = base / "kiwix-tools" / bin_name
+    if local.exists():
+        return str(local)
+    sibling = base.parent / "kiwix-tools" / bin_name
+    if sibling.exists():
+        return str(sibling)
+
+    found = shutil.which("kiwix-manage")
+    if found:
+        return found
+
+    return bin_name
+
+
 def _detect_kiwix_exe() -> str:
     """Best-effort auto-detection of the kiwix-serve binary."""
     is_windows = platform.system() == "Windows"
@@ -95,7 +115,15 @@ class Settings(BaseSettings):
 
     # --- Kiwix ---
     kiwix_exe: str = _detect_kiwix_exe()
+    kiwix_manage: str = _detect_kiwix_manage()
     kiwix_port: int = 8081
+
+    # --- ZIM management ---
+    zim_dir: Path = _detect_base_dir() / "zims"
+    upload_max_size_gb: float = 20
+    catalog_url: str = "https://library.kiwix.org/catalog/search"
+    manifest_path: Path = _detect_base_dir() / "data" / "zim_manifest.json"
+    api_key: str = ""
 
     # --- Search API server ---
     server_host: str = "0.0.0.0"

--- a/src/offline_search/indexer.py
+++ b/src/offline_search/indexer.py
@@ -40,7 +40,7 @@ def iter_articles(zim_path: Path, *, limit: int | None = None) -> Iterable[dict[
         sys.modules["gevent"] = MagicMock()
         sys.modules["gevent.monkey"] = MagicMock()
         sys.modules["gevent.pywsgi"] = MagicMock()
-    
+
     # pkg_resources was removed in python 3.12, zimply uses it for an unused falcon template
     if "pkg_resources" not in sys.modules:
         sys.modules["pkg_resources"] = MagicMock()
@@ -89,7 +89,8 @@ def iter_articles(zim_path: Path, *, limit: int | None = None) -> Iterable[dict[
                 if limit is not None and processed >= limit:
                     break
             except Exception:
-                logger.debug("Skipping article idx=%d in %s", idx, zim_path, exc_info=True)
+                logger.debug("Skipping article idx=%d in %s",
+                             idx, zim_path, exc_info=True)
     finally:
         zim.close()
 
@@ -161,7 +162,8 @@ def index_zim(
         cursor.execute(
             "INSERT INTO documents (title, content, zim_name, namespace, url) "
             "VALUES (?, ?, ?, ?, ?)",
-            (article["title"], article["content"], zim_name, article["namespace"], article["url"]),
+            (article["title"], article["content"], zim_name,
+             article["namespace"], article["url"]),
         )
         docid = cursor.lastrowid
         cursor.execute(
@@ -196,6 +198,32 @@ def index_html_page(
     )
     conn.commit()
     return cursor.lastrowid  # type: ignore[return-value]
+
+
+def remove_by_zim_path(conn: sqlite3.Connection, zim_path: str) -> int:
+    """Delete all FTS5 documents + metadata rows for a given ZIM path.
+
+    Uses the metadata table to find docids associated with *zim_path*, then
+    removes both the FTS5 rows and the metadata rows in a single transaction.
+    Returns the number of documents removed.
+    """
+    cur = conn.execute(
+        "SELECT docid FROM metadata WHERE zim_path = ?", (zim_path,)
+    )
+    docids = [row[0] for row in cur.fetchall()]
+    if not docids:
+        return 0
+
+    placeholders = ",".join("?" for _ in docids)
+    conn.execute(
+        f"DELETE FROM documents WHERE rowid IN ({placeholders})", docids
+    )
+    conn.execute(
+        f"DELETE FROM metadata WHERE docid IN ({placeholders})", docids
+    )
+    conn.commit()
+    logger.info("Removed %d documents for zim_path=%s", len(docids), zim_path)
+    return len(docids)
 
 
 def remove_by_url(conn: sqlite3.Connection, url: str) -> int:
@@ -250,7 +278,8 @@ def load_library(library_path: Path) -> Iterable[dict[str, Any]]:
 
 def main() -> None:
     """CLI: ``offline-search-index``"""
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    logging.basicConfig(level=logging.INFO,
+                        format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
         description="Build a local full-text index from ZIM files."

--- a/src/offline_search/kiwix.py
+++ b/src/offline_search/kiwix.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 # Process management
 # ---------------------------------------------------------------------------
 
+_kiwix_process: subprocess.Popen | None = None
+
+
 def is_port_open(port: int, host: str = "127.0.0.1") -> bool:
     """Return ``True`` if *port* is accepting connections."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -51,8 +54,9 @@ def start_kiwix_server(
         return True
 
     logger.info("Starting kiwix-serve on port %d …", port)
+    global _kiwix_process
     try:
-        subprocess.Popen(
+        _kiwix_process = subprocess.Popen(
             [exe, "--port", str(port), "--library", library_xml],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
@@ -75,6 +79,50 @@ def start_kiwix_server(
 
     logger.warning("Kiwix server did not respond within %.1fs", timeout)
     return False
+
+
+def stop_kiwix_server(*, timeout: float = 5.0) -> bool:
+    """Stop the kiwix-serve process started by :func:`start_kiwix_server`.
+
+    Returns ``True`` if the process was stopped (or was not running).
+    """
+    global _kiwix_process
+    if _kiwix_process is None:
+        logger.info("No kiwix-serve process to stop.")
+        return True
+
+    logger.info("Stopping kiwix-serve (pid=%d) …", _kiwix_process.pid)
+    try:
+        _kiwix_process.terminate()
+        _kiwix_process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning("kiwix-serve did not stop gracefully, killing …")
+        _kiwix_process.kill()
+        _kiwix_process.wait(timeout=2.0)
+    except Exception:
+        logger.exception("Failed to stop kiwix-serve")
+        return False
+    finally:
+        _kiwix_process = None
+
+    logger.info("kiwix-serve stopped.")
+    return True
+
+
+def restart_kiwix_server(
+    *,
+    exe: str | None = None,
+    port: int | None = None,
+    library_xml: str | None = None,
+    timeout: float = 8.0,
+) -> bool:
+    """Stop and restart kiwix-serve. Returns ``True`` if healthy after restart."""
+    stop_kiwix_server()
+    # Brief pause to release the port
+    time.sleep(0.5)
+    return start_kiwix_server(
+        exe=exe, port=port, library_xml=library_xml, timeout=timeout,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/offline_search/server.py
+++ b/src/offline_search/server.py
@@ -14,12 +14,13 @@ Or via the entry-point::
 from __future__ import annotations
 
 import logging
+import shutil
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
 import httpx
 from bs4 import BeautifulSoup
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, UploadFile
 from pydantic import BaseModel
 
 from .config import settings
@@ -28,8 +29,16 @@ from .indexer import (
     index_html_page,
     prepare_database,
     remove_by_url,
+    remove_by_zim_path,
 )
 from .search_engine import SearchResult, search_sync
+from .updater import (
+    ZIM_MAGIC,
+    export_manifest,
+    get_installed_zims,
+    ingest_zim,
+    validate_zim_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +187,146 @@ async def delete_by_url(
         return {"status": "ok", "deleted": deleted}
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# ZIM management — auth & endpoints
+# ---------------------------------------------------------------------------
+
+
+def _require_api_key(authorization: str | None = Header(None)) -> None:
+    """Dependency that enforces Bearer token auth for ZIM mutation endpoints.
+
+    If ``OFFLINE_SEARCH_API_KEY`` is empty, all mutations are **disabled**
+    (fail-closed).
+    """
+    configured_key = settings.api_key
+    if not configured_key:
+        raise HTTPException(
+            status_code=403,
+            detail="ZIM management endpoints are disabled (no API key configured)",
+        )
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    token = authorization.removeprefix("Bearer ").strip()
+    if token != configured_key:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+class IngestRequest(BaseModel):
+    zim_path: str
+    replace: bool = True
+    delete_old: bool = True
+    restart_kiwix: bool = True
+
+
+@app.get("/zim/list")
+async def zim_list():
+    """List installed ZIMs with version info."""
+    zims = get_installed_zims()
+    return [
+        {
+            "base_name": z.base_name,
+            "version": z.version,
+            "filename": z.filename,
+            "article_count": z.article_count,
+        }
+        for z in zims
+    ]
+
+
+@app.get("/zim/manifest")
+async def zim_manifest():
+    """Export a JSON manifest of installed ZIMs."""
+    return export_manifest()
+
+
+@app.post("/zim/upload", dependencies=[Depends(_require_api_key)])
+async def zim_upload(file: UploadFile):
+    """Upload a ZIM file, validate it, and run the zero-downtime ingest pipeline."""
+    if not file.filename or not file.filename.endswith(".zim"):
+        raise HTTPException(status_code=400, detail="File must have a .zim extension")
+
+    # Read first 4 bytes to validate magic
+    header = await file.read(4)
+    if header != ZIM_MAGIC:
+        raise HTTPException(status_code=400, detail="Invalid ZIM file (bad magic bytes)")
+    # Seek back so we can write the full file
+    await file.seek(0)
+
+    # Check size limit
+    max_bytes = int(settings.upload_max_size_gb * 1024 * 1024 * 1024)
+    if file.size and file.size > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large (max {settings.upload_max_size_gb} GB)",
+        )
+
+    # Stream to zim_dir
+    zim_dir = settings.zim_dir
+    zim_dir.mkdir(parents=True, exist_ok=True)
+    dest = zim_dir / file.filename
+
+    try:
+        with open(dest, "wb") as f:
+            shutil.copyfileobj(file.file, f)
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to save file: {exc}")
+
+    result = ingest_zim(dest)
+    return {
+        "success": result.success,
+        "filename": result.zim_info.filename,
+        "articles_indexed": result.articles_indexed,
+        "articles_removed": result.articles_removed,
+        "replaced": result.replaced.filename if result.replaced else None,
+        "errors": result.errors,
+    }
+
+
+@app.post("/zim/ingest", dependencies=[Depends(_require_api_key)])
+async def zim_ingest(req: IngestRequest):
+    """Ingest a ZIM file already present on disk."""
+    zim_path = Path(req.zim_path)
+    if not zim_path.exists():
+        raise HTTPException(status_code=404, detail=f"ZIM file not found: {req.zim_path}")
+    if not validate_zim_file(zim_path):
+        raise HTTPException(status_code=400, detail="Invalid ZIM file")
+
+    result = ingest_zim(
+        zim_path,
+        replace=req.replace,
+        delete_old=req.delete_old,
+        restart_kiwix=req.restart_kiwix,
+    )
+    return {
+        "success": result.success,
+        "filename": result.zim_info.filename,
+        "articles_indexed": result.articles_indexed,
+        "articles_removed": result.articles_removed,
+        "replaced": result.replaced.filename if result.replaced else None,
+        "errors": result.errors,
+    }
+
+
+@app.delete("/zim/{filename}", dependencies=[Depends(_require_api_key)])
+async def zim_delete(filename: str, keep_file: bool = Query(False)):
+    """Remove a ZIM from the library, index, and optionally disk."""
+    zims = get_installed_zims()
+    target = next((z for z in zims if z.filename == filename), None)
+    if not target:
+        raise HTTPException(status_code=404, detail=f"ZIM {filename} not found")
+
+    conn = prepare_database(settings.db_path, reset=False)
+    try:
+        removed = remove_by_zim_path(conn, str(target.zim_path))
+    finally:
+        conn.close()
+
+    if not keep_file and target.zim_path.exists():
+        target.zim_path.unlink()
+
+    return {"status": "ok", "documents_removed": removed, "file_deleted": not keep_file}
 
 
 # ---------------------------------------------------------------------------

--- a/src/offline_search/updater.py
+++ b/src/offline_search/updater.py
@@ -1,0 +1,391 @@
+"""Server-side ZIM update management — zero-downtime ingest pipeline.
+
+Handles ZIM file validation, version parsing, library.xml integration,
+and the atomic index-then-swap strategy that keeps old content serving
+while new content is being indexed.
+
+CLI: ``offline-search-update``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from .config import settings
+from .indexer import (
+    get_index_stats,
+    index_zim,
+    load_library,
+    prepare_database,
+    remove_by_zim_path,
+)
+from .kiwix import restart_kiwix_server
+
+logger = logging.getLogger(__name__)
+
+# ZIM magic bytes: 0x44 0x49 0x4D 0x04  (ASCII "DIM" + 0x04)
+ZIM_MAGIC = b"\x44\x49\x4d\x04"
+
+# Regex to parse versioned ZIM filenames: basename_YYYY-MM
+_VERSION_RE = re.compile(r"^(.+?)_(\d{4}-\d{2})$")
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ZimInfo:
+    base_name: str
+    version: str
+    filename: str
+    zim_path: Path
+    article_count: int = 0
+
+
+@dataclass
+class IngestResult:
+    success: bool
+    zim_info: ZimInfo
+    replaced: ZimInfo | None = None
+    articles_indexed: int = 0
+    articles_removed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Version parsing
+# ---------------------------------------------------------------------------
+
+def parse_zim_version(filename: str) -> tuple[str, str]:
+    """Extract ``(base_name, version)`` from a ZIM filename stem.
+
+    >>> parse_zim_version("devdocs_en_python_2026-01")
+    ('devdocs_en_python', '2026-01')
+
+    Raises ``ValueError`` if the filename doesn't match the expected pattern.
+    """
+    stem = Path(filename).stem
+    m = _VERSION_RE.match(stem)
+    if not m:
+        raise ValueError(
+            f"Cannot parse version from {filename!r}. "
+            f"Expected pattern: <name>_YYYY-MM.zim"
+        )
+    return m.group(1), m.group(2)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_zim_file(path: Path) -> bool:
+    """Check that *path* looks like a valid ZIM file (extension + magic bytes)."""
+    if not path.is_file():
+        return False
+    if path.suffix.lower() != ".zim":
+        return False
+    try:
+        with open(path, "rb") as f:
+            header = f.read(4)
+        return header == ZIM_MAGIC
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Installed ZIM queries
+# ---------------------------------------------------------------------------
+
+def get_installed_zims(library_xml: Path | None = None) -> list[ZimInfo]:
+    """Parse library.xml and return a list of installed ZIMs with metadata."""
+    lib_path = library_xml or Path(settings.library_xml)
+    if not lib_path.exists():
+        return []
+
+    results: list[ZimInfo] = []
+    stats = get_index_stats()
+    source_counts = {s["name"]: s["count"] for s in stats.get("sources", [])}
+
+    for entry in load_library(lib_path):
+        zim_path: Path = entry["zim_path"]
+        filename = zim_path.name
+        try:
+            base_name, version = parse_zim_version(filename)
+        except ValueError:
+            base_name = zim_path.stem
+            version = "unknown"
+        results.append(ZimInfo(
+            base_name=base_name,
+            version=version,
+            filename=filename,
+            zim_path=zim_path,
+            article_count=source_counts.get(zim_path.stem, 0),
+        ))
+    return results
+
+
+def find_older_version(
+    base_name: str,
+    library_xml: Path | None = None,
+) -> ZimInfo | None:
+    """Find an installed ZIM with the same base_name (i.e. an older version)."""
+    for zim in get_installed_zims(library_xml):
+        if zim.base_name == base_name:
+            return zim
+    return None
+
+
+# ---------------------------------------------------------------------------
+# kiwix-manage helpers
+# ---------------------------------------------------------------------------
+
+def _run_kiwix_manage(library_xml: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run kiwix-manage with the given arguments."""
+    cmd = [settings.kiwix_manage, str(library_xml), *args]
+    logger.debug("Running: %s", " ".join(cmd))
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def kiwix_manage_add(library_xml: Path, zim_path: Path) -> bool:
+    """Add a ZIM to library.xml via kiwix-manage."""
+    result = _run_kiwix_manage(library_xml, "add", str(zim_path))
+    if result.returncode != 0:
+        logger.error("kiwix-manage add failed: %s", result.stderr)
+        return False
+    return True
+
+
+def kiwix_manage_remove(library_xml: Path, zim_id: str) -> bool:
+    """Remove a ZIM from library.xml via kiwix-manage."""
+    result = _run_kiwix_manage(library_xml, "remove", zim_id)
+    if result.returncode != 0:
+        logger.error("kiwix-manage remove failed: %s", result.stderr)
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Zero-downtime ingest pipeline
+# ---------------------------------------------------------------------------
+
+def ingest_zim(
+    zim_path: Path,
+    *,
+    replace: bool = True,
+    delete_old: bool = True,
+    restart_kiwix: bool = True,
+    library_xml: Path | None = None,
+    db_path: Path | None = None,
+) -> IngestResult:
+    """Zero-downtime ZIM ingestion pipeline.
+
+    1. Parse version info, find any existing older version
+    2. Add new ZIM to library.xml (old + new coexist)
+    3. Index the new ZIM into the database (old still serves searches)
+    4. Atomic swap: remove old ZIM's rows from the database
+    5. Remove old ZIM from library.xml
+    6. Optionally delete old .zim file from disk
+    7. Optionally restart kiwix-serve
+    """
+    lib_xml = library_xml or Path(settings.library_xml)
+    db = db_path or settings.db_path
+    errors: list[str] = []
+
+    # --- Validate ---
+    if not validate_zim_file(zim_path):
+        return IngestResult(
+            success=False,
+            zim_info=ZimInfo("", "", zim_path.name, zim_path),
+            errors=["Invalid ZIM file: bad magic bytes or extension"],
+        )
+
+    # --- Parse version ---
+    try:
+        base_name, version = parse_zim_version(zim_path.name)
+    except ValueError as exc:
+        return IngestResult(
+            success=False,
+            zim_info=ZimInfo("", "", zim_path.name, zim_path),
+            errors=[str(exc)],
+        )
+
+    zim_info = ZimInfo(
+        base_name=base_name,
+        version=version,
+        filename=zim_path.name,
+        zim_path=zim_path,
+    )
+
+    # --- Find older version ---
+    old_zim: ZimInfo | None = None
+    if replace:
+        old_zim = find_older_version(base_name, lib_xml)
+
+    # --- Step 1: Add new ZIM to library.xml ---
+    if not kiwix_manage_add(lib_xml, zim_path):
+        errors.append("kiwix-manage add failed (continuing with indexing)")
+
+    # --- Step 2: Index new ZIM (this is the slow part) ---
+    conn = prepare_database(db, reset=False)
+    try:
+        articles_indexed = index_zim(
+            conn, zim_path, zim_path.stem,
+        )
+        zim_info.article_count = articles_indexed
+
+        # --- Step 3: Atomic swap — remove old rows ---
+        articles_removed = 0
+        if old_zim is not None and old_zim.zim_path != zim_path:
+            articles_removed = remove_by_zim_path(conn, str(old_zim.zim_path))
+
+            # --- Step 4: Remove old from library.xml ---
+            # kiwix-manage remove uses the book ID, which is typically the stem
+            if not kiwix_manage_remove(lib_xml, old_zim.zim_path.stem):
+                errors.append("kiwix-manage remove of old ZIM failed")
+
+            # --- Step 5: Delete old file ---
+            if delete_old and old_zim.zim_path.exists():
+                try:
+                    old_zim.zim_path.unlink()
+                    logger.info("Deleted old ZIM: %s", old_zim.zim_path)
+                except OSError as exc:
+                    errors.append(f"Failed to delete old ZIM: {exc}")
+    finally:
+        conn.close()
+
+    # --- Step 6: Restart kiwix-serve ---
+    if restart_kiwix:
+        if not restart_kiwix_server():
+            errors.append("kiwix-serve restart failed")
+
+    return IngestResult(
+        success=True,
+        zim_info=zim_info,
+        replaced=old_zim,
+        articles_indexed=articles_indexed,
+        articles_removed=articles_removed,
+        errors=errors,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manifest export
+# ---------------------------------------------------------------------------
+
+def export_manifest(library_xml: Path | None = None) -> list[dict]:
+    """Export installed ZIMs as a JSON-serialisable manifest."""
+    zims = get_installed_zims(library_xml)
+    return [
+        {
+            "base_name": z.base_name,
+            "version": z.version,
+            "filename": z.filename,
+            "article_count": z.article_count,
+        }
+        for z in zims
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """CLI: ``offline-search-update``"""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    parser = argparse.ArgumentParser(description="Manage ZIM files in the offline search system.")
+    sub = parser.add_subparsers(dest="command")
+
+    # ingest
+    p_ingest = sub.add_parser("ingest", help="Ingest a ZIM file (zero-downtime)")
+    p_ingest.add_argument("zim_path", type=Path, nargs="+", help="ZIM file(s) to ingest")
+    p_ingest.add_argument("--no-replace", action="store_true", help="Don't replace older versions")
+    p_ingest.add_argument("--keep-old", action="store_true", help="Keep old ZIM file on disk")
+    p_ingest.add_argument("--no-restart", action="store_true", help="Don't restart kiwix-serve")
+
+    # list
+    sub.add_parser("list", help="List installed ZIMs")
+
+    # remove
+    p_remove = sub.add_parser("remove", help="Remove a ZIM from the library and index")
+    p_remove.add_argument("filename", help="ZIM filename to remove")
+    p_remove.add_argument("--keep-file", action="store_true", help="Keep the .zim file on disk")
+
+    # manifest
+    p_manifest = sub.add_parser("manifest", help="Export a JSON manifest of installed ZIMs")
+    p_manifest.add_argument("--output", type=Path, help="Write manifest to file (default: stdout)")
+
+    args = parser.parse_args()
+
+    if args.command == "ingest":
+        for zp in args.zim_path:
+            result = ingest_zim(
+                zp,
+                replace=not args.no_replace,
+                delete_old=not args.keep_old,
+                restart_kiwix=not args.no_restart,
+            )
+            if result.success:
+                logger.info(
+                    "Ingested %s: %d articles indexed, %d removed",
+                    result.zim_info.filename,
+                    result.articles_indexed,
+                    result.articles_removed,
+                )
+            else:
+                logger.error("Failed to ingest %s: %s", zp, result.errors)
+
+    elif args.command == "list":
+        zims = get_installed_zims()
+        if not zims:
+            print("No ZIMs installed.")
+            return
+        for z in zims:
+            print(f"  {z.filename}  (base={z.base_name}, version={z.version}, articles={z.article_count})")
+
+    elif args.command == "remove":
+        lib_xml = Path(settings.library_xml)
+        db = settings.db_path
+        # Find the ZIM
+        zims = get_installed_zims(lib_xml)
+        target = next((z for z in zims if z.filename == args.filename), None)
+        if not target:
+            logger.error("ZIM %s not found in library", args.filename)
+            return
+        # Remove from index
+        conn = prepare_database(db, reset=False)
+        try:
+            removed = remove_by_zim_path(conn, str(target.zim_path))
+            logger.info("Removed %d documents from index", removed)
+        finally:
+            conn.close()
+        # Remove from library.xml
+        kiwix_manage_remove(lib_xml, target.zim_path.stem)
+        # Delete file
+        if not args.keep_file and target.zim_path.exists():
+            target.zim_path.unlink()
+            logger.info("Deleted %s", target.zim_path)
+
+    elif args.command == "manifest":
+        manifest = export_manifest()
+        output = json.dumps(manifest, indent=2)
+        if args.output:
+            args.output.write_text(output, encoding="utf-8")
+            logger.info("Manifest written to %s", args.output)
+        else:
+            print(output)
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/offline_search/updater.py
+++ b/src/offline_search/updater.py
@@ -30,7 +30,7 @@ from .kiwix import restart_kiwix_server
 logger = logging.getLogger(__name__)
 
 # ZIM magic bytes: 0x44 0x49 0x4D 0x04  (ASCII "DIM" + 0x04)
-ZIM_MAGIC = b"\x44\x49\x4d\x04"
+ZIM_MAGIC = b"ZIM\x04"
 
 # Regex to parse versioned ZIM filenames: basename_YYYY-MM
 _VERSION_RE = re.compile(r"^(.+?)_(\d{4}-\d{2})$")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,251 @@
+"""Tests for the catalog module — OPDS parsing, version comparison, checksum, manifest."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from offline_search.catalog import (
+    CatalogEntry,
+    WatchConfig,
+    _parse_opds_feed,
+    compare_versions,
+    download_zim,
+    export_manifest,
+    fetch_catalog,
+    load_manifest,
+    verify_checksum,
+)
+from offline_search.updater import ZimInfo
+
+
+# ---------------------------------------------------------------------------
+# OPDS parsing
+# ---------------------------------------------------------------------------
+
+SAMPLE_OPDS = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Python DevDocs</title>
+    <summary>Python documentation from DevDocs</summary>
+    <link type="application/x-zim"
+          href="https://mirror.example.com/devdocs_en_python_2026-01.zim"
+          length="52428800"/>
+  </entry>
+  <entry>
+    <title>Wikipedia English</title>
+    <summary>English Wikipedia</summary>
+    <link type="application/x-zim"
+          href="https://mirror.example.com/wikipedia_en_2025-11.zim"
+          length="104857600"/>
+  </entry>
+</feed>
+"""
+
+
+class TestParseCatalog:
+    def test_parses_entries(self):
+        entries = _parse_opds_feed(SAMPLE_OPDS)
+        assert len(entries) == 2
+
+    def test_entry_fields(self):
+        entries = _parse_opds_feed(SAMPLE_OPDS)
+        e = entries[0]
+        assert e.name == "devdocs_en_python"
+        assert e.version == "2026-01"
+        assert e.title == "Python DevDocs"
+        assert e.description == "Python documentation from DevDocs"
+        assert "devdocs_en_python_2026-01.zim" in e.url
+        assert e.size == 52428800
+
+    def test_second_entry(self):
+        entries = _parse_opds_feed(SAMPLE_OPDS)
+        e = entries[1]
+        assert e.name == "wikipedia_en"
+        assert e.version == "2025-11"
+
+    def test_empty_feed(self):
+        xml = '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>'
+        assert _parse_opds_feed(xml) == []
+
+    def test_entry_without_zim_link(self):
+        xml = """\
+<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>No ZIM</title>
+    <link type="text/html" href="https://example.com"/>
+  </entry>
+</feed>"""
+        entries = _parse_opds_feed(xml)
+        assert len(entries) == 1
+        assert entries[0].url == ""
+
+
+class TestFetchCatalog:
+    def test_fetches_and_parses(self):
+        mock_resp = MagicMock()
+        mock_resp.text = SAMPLE_OPDS
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        with patch("offline_search.catalog.httpx.Client", return_value=mock_client):
+            entries = fetch_catalog(query="python", catalog_url="https://example.com/catalog")
+
+        assert len(entries) == 2
+        mock_client.get.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Version comparison
+# ---------------------------------------------------------------------------
+
+class TestCompareVersions:
+    def test_finds_newer_version(self):
+        installed = [
+            ZimInfo("devdocs_en_python", "2025-01", "devdocs_en_python_2025-01.zim", Path("/z")),
+        ]
+        catalog = [
+            CatalogEntry("devdocs_en_python", "2026-01", "Python DevDocs", "", "url", 0, "en", ""),
+        ]
+        updates = compare_versions(installed, catalog)
+        assert len(updates) == 1
+        assert updates[0].available.version == "2026-01"
+
+    def test_no_update_when_same_version(self):
+        installed = [
+            ZimInfo("wiki_en", "2025-03", "wiki_en_2025-03.zim", Path("/z")),
+        ]
+        catalog = [
+            CatalogEntry("wiki_en", "2025-03", "Wikipedia", "", "url", 0, "en", ""),
+        ]
+        assert compare_versions(installed, catalog) == []
+
+    def test_no_update_when_older_in_catalog(self):
+        installed = [
+            ZimInfo("wiki_en", "2026-01", "wiki_en_2026-01.zim", Path("/z")),
+        ]
+        catalog = [
+            CatalogEntry("wiki_en", "2025-01", "Wikipedia", "", "url", 0, "en", ""),
+        ]
+        assert compare_versions(installed, catalog) == []
+
+    def test_ignores_uninstalled(self):
+        """Catalog entries for ZIMs not installed locally should be ignored."""
+        installed = [
+            ZimInfo("wiki_en", "2025-01", "wiki_en_2025-01.zim", Path("/z")),
+        ]
+        catalog = [
+            CatalogEntry("devdocs_python", "2026-01", "Python", "", "url", 0, "en", ""),
+        ]
+        assert compare_versions(installed, catalog) == []
+
+
+# ---------------------------------------------------------------------------
+# Checksum verification
+# ---------------------------------------------------------------------------
+
+class TestVerifyChecksum:
+    def test_valid_checksum(self, tmp_path):
+        f = tmp_path / "test.bin"
+        content = b"hello world"
+        f.write_bytes(content)
+        expected = hashlib.sha256(content).hexdigest()
+        assert verify_checksum(f, expected) is True
+
+    def test_invalid_checksum(self, tmp_path):
+        f = tmp_path / "test.bin"
+        f.write_bytes(b"hello world")
+        assert verify_checksum(f, "0" * 64) is False
+
+    def test_empty_checksum_skips(self, tmp_path):
+        f = tmp_path / "test.bin"
+        f.write_bytes(b"data")
+        assert verify_checksum(f, "") is True
+
+
+# ---------------------------------------------------------------------------
+# Download with checksum
+# ---------------------------------------------------------------------------
+
+class TestDownloadZim:
+    def test_download_and_verify(self, tmp_path):
+        """Successful download should write file and verify checksum."""
+        content = b"fake zim content"
+        sha = hashlib.sha256(content).hexdigest()
+        entry = CatalogEntry("test", "2026-01", "Test", "", "https://example.com/test_2026-01.zim", len(content), "en", sha)
+
+        # Mock streaming response
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.iter_bytes.return_value = [content]
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_client = MagicMock()
+        mock_client.stream.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        with patch("offline_search.catalog.httpx.Client", return_value=mock_client):
+            path = download_zim(entry, tmp_path)
+
+        assert path.exists()
+        assert path.read_bytes() == content
+
+    def test_download_checksum_mismatch_deletes_file(self, tmp_path):
+        """If checksum fails, the downloaded file should be deleted."""
+        content = b"fake zim content"
+        entry = CatalogEntry("test", "2026-01", "Test", "", "https://example.com/test_2026-01.zim", len(content), "en", "bad_checksum")
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.iter_bytes.return_value = [content]
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_client = MagicMock()
+        mock_client.stream.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        with patch("offline_search.catalog.httpx.Client", return_value=mock_client):
+            with pytest.raises(ValueError, match="Checksum verification failed"):
+                download_zim(entry, tmp_path)
+
+        # File should be cleaned up
+        assert not (tmp_path / "test_2026-01.zim").exists()
+
+
+# ---------------------------------------------------------------------------
+# Manifest round-trip
+# ---------------------------------------------------------------------------
+
+class TestManifestRoundTrip:
+    def test_export_and_load(self, tmp_path):
+        zims = [
+            ZimInfo("wiki_en", "2025-03", "wiki_en_2025-03.zim", Path("/z/wiki_en_2025-03.zim")),
+            ZimInfo("devdocs_python", "2026-01", "devdocs_python_2026-01.zim", Path("/z/devdocs_python_2026-01.zim")),
+        ]
+        manifest_path = tmp_path / "manifest.json"
+        export_manifest(zims, manifest_path)
+
+        loaded = load_manifest(manifest_path)
+        assert len(loaded) == 2
+        assert loaded[0].base_name == "wiki_en"
+        assert loaded[0].version == "2025-03"
+        assert loaded[1].base_name == "devdocs_python"
+
+    def test_load_empty_manifest(self, tmp_path):
+        p = tmp_path / "empty.json"
+        p.write_text("[]", encoding="utf-8")
+        assert load_manifest(p) == []

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -13,6 +13,7 @@ from offline_search.catalog import (
     CatalogEntry,
     WatchConfig,
     _parse_opds_feed,
+    check_updates_for_installed,
     compare_versions,
     download_zim,
     export_manifest,
@@ -148,6 +149,88 @@ class TestCompareVersions:
             CatalogEntry("devdocs_python", "2026-01", "Python", "", "url", 0, "en", ""),
         ]
         assert compare_versions(installed, catalog) == []
+
+
+# ---------------------------------------------------------------------------
+# Update checking (bug fix: single-page truncation)
+# ---------------------------------------------------------------------------
+
+class TestCheckUpdatesForInstalled:
+    """check_updates_for_installed must find updates for ALL installed ZIMs,
+    even those that would not appear on the catalog's default first page."""
+
+    def _fake_catalog(self, catalog: dict[str, CatalogEntry]):
+        """Return a fetch_catalog stub backed by a name→entry dict.
+
+        A query matching an entry's name returns that entry.
+        A parameterless call returns nothing — simulating the real catalog's
+        first-page truncation that caused the original bug.
+        """
+        def fake_fetch(query=None, *, catalog_url=None, verify_tls=True, timeout=30.0):
+            if query and query in catalog:
+                return [catalog[query]]
+            return []
+        return fake_fetch
+
+    def test_finds_updates_for_all_installed_zims(self):
+        """Updates are found for every installed ZIM, not just those on page 1."""
+        installed = [
+            ZimInfo("reverseengineering.stackexchange.com_en_all", "2025-12",
+                    "reverseengineering.stackexchange.com_en_all_2025-12.zim", Path("/z")),
+            ZimInfo("devdocs_en_python", "2025-06",
+                    "devdocs_en_python_2025-06.zim", Path("/z")),
+        ]
+        catalog = {
+            "reverseengineering.stackexchange.com_en_all": CatalogEntry(
+                "reverseengineering.stackexchange.com_en_all", "2026-02",
+                "RE Stack Exchange", "", "https://mirror/re_2026-02.zim", 1024, "en", "",
+            ),
+            "devdocs_en_python": CatalogEntry(
+                "devdocs_en_python", "2026-01",
+                "Python DevDocs", "", "https://mirror/devdocs_2026-01.zim", 1024, "en", "",
+            ),
+        }
+
+        with patch("offline_search.catalog.fetch_catalog", side_effect=self._fake_catalog(catalog)):
+            updates = check_updates_for_installed(installed)
+
+        updated_names = {u.installed.base_name for u in updates}
+        assert updated_names == {
+            "reverseengineering.stackexchange.com_en_all",
+            "devdocs_en_python",
+        }
+
+    def test_no_updates_when_all_current(self):
+        installed = [
+            ZimInfo("wiki_en", "2026-01", "wiki_en_2026-01.zim", Path("/z")),
+        ]
+        catalog = {
+            "wiki_en": CatalogEntry("wiki_en", "2026-01", "Wiki", "", "url", 0, "en", ""),
+        }
+
+        with patch("offline_search.catalog.fetch_catalog", side_effect=self._fake_catalog(catalog)):
+            updates = check_updates_for_installed(installed)
+
+        assert updates == []
+
+    def test_mixed_some_updated_some_current(self):
+        """Only ZIMs with newer catalog versions appear in updates."""
+        installed = [
+            ZimInfo("alpha", "2025-01", "alpha_2025-01.zim", Path("/z")),
+            ZimInfo("beta", "2026-01", "beta_2026-01.zim", Path("/z")),
+            ZimInfo("gamma", "2025-06", "gamma_2025-06.zim", Path("/z")),
+        ]
+        catalog = {
+            "alpha": CatalogEntry("alpha", "2026-01", "", "", "url", 0, "en", ""),
+            "beta": CatalogEntry("beta", "2026-01", "", "", "url", 0, "en", ""),   # same
+            "gamma": CatalogEntry("gamma", "2026-02", "", "", "url", 0, "en", ""),
+        }
+
+        with patch("offline_search.catalog.fetch_catalog", side_effect=self._fake_catalog(catalog)):
+            updates = check_updates_for_installed(installed)
+
+        updated_names = {u.installed.base_name for u in updates}
+        assert updated_names == {"alpha", "gamma"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -13,6 +13,7 @@ from offline_search.indexer import (
     load_library,
     prepare_database,
     remove_by_url,
+    remove_by_zim_path,
 )
 
 
@@ -124,6 +125,74 @@ class TestRemoveByUrl:
         index_html_page(conn, title="A", content="c", url="http://a.com")
         deleted = remove_by_url(conn, "http://nonexistent.com")
         assert deleted == 0
+        conn.close()
+
+
+class TestRemoveByZimPath:
+    def test_removes_matching_documents(self, tmp_path):
+        """Documents associated with a given zim_path should be removed."""
+        db_path = tmp_path / "idx.sqlite"
+        conn = prepare_database(db_path, reset=True)
+        # Insert two docs from different ZIM paths
+        cur = conn.execute(
+            "INSERT INTO documents (title, content, zim_name, namespace, url) "
+            "VALUES ('A', 'content a', 'zim_a', 'A', 'ua')"
+        )
+        conn.execute("INSERT INTO metadata (docid, zim_path) VALUES (?, '/path/a.zim')", (cur.lastrowid,))
+        cur = conn.execute(
+            "INSERT INTO documents (title, content, zim_name, namespace, url) "
+            "VALUES ('B', 'content b', 'zim_b', 'A', 'ub')"
+        )
+        conn.execute("INSERT INTO metadata (docid, zim_path) VALUES (?, '/path/b.zim')", (cur.lastrowid,))
+        conn.commit()
+
+        removed = remove_by_zim_path(conn, "/path/a.zim")
+        assert removed == 1
+
+        # Only B should remain
+        count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert count == 1
+        title = conn.execute("SELECT title FROM documents").fetchone()[0]
+        assert title == "B"
+
+        # Metadata for A should also be gone
+        meta = conn.execute("SELECT COUNT(*) FROM metadata WHERE zim_path = '/path/a.zim'").fetchone()[0]
+        assert meta == 0
+        conn.close()
+
+    def test_removes_nothing_when_no_match(self, tmp_path):
+        db_path = tmp_path / "idx.sqlite"
+        conn = prepare_database(db_path, reset=True)
+        cur = conn.execute(
+            "INSERT INTO documents (title, content, zim_name, namespace, url) "
+            "VALUES ('A', 'c', 'z', 'A', 'u')"
+        )
+        conn.execute("INSERT INTO metadata (docid, zim_path) VALUES (?, '/path/a.zim')", (cur.lastrowid,))
+        conn.commit()
+
+        removed = remove_by_zim_path(conn, "/path/nonexistent.zim")
+        assert removed == 0
+        count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert count == 1
+        conn.close()
+
+    def test_removes_multiple_documents(self, tmp_path):
+        """All documents from the same ZIM should be removed in one call."""
+        db_path = tmp_path / "idx.sqlite"
+        conn = prepare_database(db_path, reset=True)
+        for i in range(5):
+            cur = conn.execute(
+                "INSERT INTO documents (title, content, zim_name, namespace, url) "
+                "VALUES (?, ?, 'zim', 'A', ?)",
+                (f"Title {i}", f"Content {i}", f"url{i}"),
+            )
+            conn.execute("INSERT INTO metadata (docid, zim_path) VALUES (?, '/path/target.zim')", (cur.lastrowid,))
+        conn.commit()
+
+        removed = remove_by_zim_path(conn, "/path/target.zim")
+        assert removed == 5
+        count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert count == 0
         conn.close()
 
 

--- a/tests/test_kiwix.py
+++ b/tests/test_kiwix.py
@@ -10,8 +10,11 @@ from unittest.mock import MagicMock, patch
 from offline_search.kiwix import (
     html_to_markdown,
     is_port_open,
+    restart_kiwix_server,
     start_kiwix_server,
+    stop_kiwix_server,
 )
+import offline_search.kiwix as kiwix_mod
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +111,60 @@ class TestStartKiwixServer:
             assert start_kiwix_server(
                 exe="kiwix-serve", port=8081, library_xml="lib.xml", timeout=2.0,
             ) is False
+
+
+# ---------------------------------------------------------------------------
+# stop_kiwix_server
+# ---------------------------------------------------------------------------
+
+class TestStopKiwixServer:
+    def test_stop_when_no_process(self):
+        """Stopping when nothing is running should return True."""
+        kiwix_mod._kiwix_process = None
+        assert stop_kiwix_server() is True
+
+    def test_stop_running_process(self):
+        """Terminate a running process."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        kiwix_mod._kiwix_process = mock_proc
+
+        assert stop_kiwix_server() is True
+        mock_proc.terminate.assert_called_once()
+        mock_proc.wait.assert_called_once()
+        assert kiwix_mod._kiwix_process is None
+
+    def test_stop_kills_on_timeout(self):
+        """If terminate times out, kill should be called."""
+        import subprocess as sp
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.wait.side_effect = [sp.TimeoutExpired("kiwix-serve", 5), None]
+        kiwix_mod._kiwix_process = mock_proc
+
+        assert stop_kiwix_server() is True
+        mock_proc.kill.assert_called_once()
+        assert kiwix_mod._kiwix_process is None
+
+
+# ---------------------------------------------------------------------------
+# restart_kiwix_server
+# ---------------------------------------------------------------------------
+
+class TestRestartKiwixServer:
+    def test_restart_calls_stop_then_start(self):
+        """Restart should stop first, then start."""
+        with (
+            patch("offline_search.kiwix.stop_kiwix_server", return_value=True) as mock_stop,
+            patch("offline_search.kiwix.start_kiwix_server", return_value=True) as mock_start,
+            patch("offline_search.kiwix.time.sleep"),
+        ):
+            result = restart_kiwix_server(
+                exe="kiwix-serve", port=8081, library_xml="lib.xml",
+            )
+            assert result is True
+            mock_stop.assert_called_once()
+            mock_start.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -211,6 +211,108 @@ class TestCrawlEndpoint:
         assert data["pages_indexed"] >= 1
 
 
+class TestZimListEndpoint:
+    """The /zim/list and /zim/manifest endpoints are public (no auth)."""
+
+    def test_zim_list(self, client):
+        with patch("offline_search.server.get_installed_zims", return_value=[]):
+            resp = client.get("/zim/list")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_zim_manifest(self, client):
+        with patch("offline_search.server.export_manifest", return_value=[]):
+            resp = client.get("/zim/manifest")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestZimAuthEnforcement:
+    """Mutation endpoints must enforce API key auth."""
+
+    def test_upload_without_key_configured_returns_403(self, client, monkeypatch):
+        """When no API key is configured, mutations are disabled."""
+        monkeypatch.setattr(settings, "api_key", "")
+        resp = client.post("/zim/upload", files={"file": ("t.zim", b"x", "application/octet-stream")})
+        assert resp.status_code == 403
+
+    def test_upload_without_auth_header_returns_401(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "api_key", "test-secret")
+        resp = client.post("/zim/upload", files={"file": ("t.zim", b"x", "application/octet-stream")})
+        assert resp.status_code == 401
+
+    def test_upload_with_wrong_key_returns_401(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "api_key", "test-secret")
+        resp = client.post(
+            "/zim/upload",
+            files={"file": ("t.zim", b"x", "application/octet-stream")},
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert resp.status_code == 401
+
+    def test_ingest_without_key_returns_403(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "api_key", "")
+        resp = client.post("/zim/ingest", json={"zim_path": "/fake.zim"})
+        assert resp.status_code == 403
+
+    def test_delete_without_key_returns_403(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "api_key", "")
+        resp = client.delete("/zim/test.zim")
+        assert resp.status_code == 403
+
+
+class TestZimUploadValidation:
+    """Upload endpoint validates file extension and magic bytes."""
+
+    def _auth_headers(self):
+        return {"Authorization": "Bearer test-secret"}
+
+    def test_rejects_non_zim_extension(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "api_key", "test-secret")
+        resp = client.post(
+            "/zim/upload",
+            files={"file": ("test.txt", b"\x44\x49\x4d\x04" + b"\x00" * 100, "application/octet-stream")},
+            headers=self._auth_headers(),
+        )
+        assert resp.status_code == 400
+        assert "extension" in resp.json()["detail"].lower()
+
+    def test_rejects_bad_magic_bytes(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "api_key", "test-secret")
+        resp = client.post(
+            "/zim/upload",
+            files={"file": ("test_2025-01.zim", b"\x00\x00\x00\x00" + b"\x00" * 100, "application/octet-stream")},
+            headers=self._auth_headers(),
+        )
+        assert resp.status_code == 400
+        assert "magic" in resp.json()["detail"].lower()
+
+    def test_accepts_valid_upload(self, client, monkeypatch, tmp_path):
+        """Valid ZIM upload triggers the ingest pipeline."""
+        monkeypatch.setattr(settings, "api_key", "test-secret")
+        monkeypatch.setattr(settings, "zim_dir", tmp_path / "zims")
+
+        from offline_search.updater import IngestResult, ZimInfo
+        mock_result = IngestResult(
+            success=True,
+            zim_info=ZimInfo("test_en", "2025-01", "test_en_2025-01.zim", tmp_path / "test_en_2025-01.zim", 42),
+            articles_indexed=42,
+        )
+
+        content = b"\x44\x49\x4d\x04" + b"\x00" * 100
+        with patch("offline_search.server.ingest_zim", return_value=mock_result):
+            resp = client.post(
+                "/zim/upload",
+                files={"file": ("test_en_2025-01.zim", content, "application/octet-stream")},
+                headers=self._auth_headers(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["articles_indexed"] == 42
+
+
 class TestServerMain:
     """Smoke test for the server CLI entry point."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -299,7 +299,7 @@ class TestZimUploadValidation:
             articles_indexed=42,
         )
 
-        content = b"\x44\x49\x4d\x04" + b"\x00" * 100
+        content = b"\x5a\x49\x4d\x04" + b"\x00" * 100  # ZIM magic: "ZIM\x04"
         with patch("offline_search.server.ingest_zim", return_value=mock_result):
             resp = client.post(
                 "/zim/upload",

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,306 @@
+"""Tests for the updater module — ZIM version parsing, validation, and zero-downtime ingest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from offline_search.indexer import prepare_database
+from offline_search.updater import (
+    IngestResult,
+    ZimInfo,
+    ZIM_MAGIC,
+    export_manifest,
+    find_older_version,
+    get_installed_zims,
+    ingest_zim,
+    parse_zim_version,
+    validate_zim_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Version parsing
+# ---------------------------------------------------------------------------
+
+class TestParseZimVersion:
+    def test_standard_filename(self):
+        base, ver = parse_zim_version("devdocs_en_python_2026-01.zim")
+        assert base == "devdocs_en_python"
+        assert ver == "2026-01"
+
+    def test_no_extension(self):
+        base, ver = parse_zim_version("wikipedia_en_2025-03")
+        assert base == "wikipedia_en"
+        assert ver == "2025-03"
+
+    def test_multiple_underscores(self):
+        base, ver = parse_zim_version("stack_overflow_en_all_2025-11.zim")
+        assert base == "stack_overflow_en_all"
+        assert ver == "2025-11"
+
+    def test_invalid_no_version(self):
+        with pytest.raises(ValueError, match="Cannot parse version"):
+            parse_zim_version("no_version_here.zim")
+
+    def test_invalid_bad_date(self):
+        with pytest.raises(ValueError, match="Cannot parse version"):
+            parse_zim_version("test_20251.zim")
+
+
+# ---------------------------------------------------------------------------
+# ZIM file validation
+# ---------------------------------------------------------------------------
+
+class TestValidateZimFile:
+    def test_valid_zim(self, tmp_path):
+        zim = tmp_path / "test_2025-01.zim"
+        zim.write_bytes(ZIM_MAGIC + b"\x00" * 100)
+        assert validate_zim_file(zim) is True
+
+    def test_wrong_magic(self, tmp_path):
+        zim = tmp_path / "test_2025-01.zim"
+        zim.write_bytes(b"\x00\x00\x00\x00" + b"\x00" * 100)
+        assert validate_zim_file(zim) is False
+
+    def test_wrong_extension(self, tmp_path):
+        notazim = tmp_path / "test_2025-01.txt"
+        notazim.write_bytes(ZIM_MAGIC + b"\x00" * 100)
+        assert validate_zim_file(notazim) is False
+
+    def test_nonexistent(self, tmp_path):
+        assert validate_zim_file(tmp_path / "missing.zim") is False
+
+    def test_directory(self, tmp_path):
+        assert validate_zim_file(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# Zero-downtime ingest pipeline
+# ---------------------------------------------------------------------------
+
+class TestIngestZim:
+    """Test the full ingest pipeline with mocked system boundaries."""
+
+    def _make_zim(self, tmp_path: Path, name: str) -> Path:
+        """Create a fake ZIM file with valid magic bytes."""
+        zim = tmp_path / name
+        zim.write_bytes(ZIM_MAGIC + b"\x00" * 100)
+        return zim
+
+    def _make_library_xml(self, tmp_path: Path, entries: list[str]) -> Path:
+        """Create a minimal library.xml."""
+        books = "\n".join(f'  <book path="{e}"/>' for e in entries)
+        xml = f'<?xml version="1.0"?>\n<library>\n{books}\n</library>'
+        lib = tmp_path / "library.xml"
+        lib.write_text(xml, encoding="utf-8")
+        return lib
+
+    def test_ingest_new_zim(self, tmp_path):
+        """Ingesting a new ZIM should index articles and report success."""
+        zim = self._make_zim(tmp_path, "devdocs_en_python_2026-01.zim")
+        lib_xml = self._make_library_xml(tmp_path, [])
+        db_path = tmp_path / "idx.sqlite"
+
+        fake_articles = [
+            {"namespace": "A", "url": "p1", "title": "Page 1", "content": "Content one"},
+            {"namespace": "A", "url": "p2", "title": "Page 2", "content": "Content two"},
+        ]
+
+        with (
+            patch("offline_search.updater.kiwix_manage_add", return_value=True),
+            patch("offline_search.updater.restart_kiwix_server", return_value=True),
+            patch("offline_search.indexer.iter_articles", return_value=fake_articles),
+        ):
+            result = ingest_zim(
+                zim, library_xml=lib_xml, db_path=db_path, restart_kiwix=False,
+            )
+
+        assert result.success is True
+        assert result.articles_indexed == 2
+        assert result.zim_info.base_name == "devdocs_en_python"
+        assert result.zim_info.version == "2026-01"
+
+    def test_ingest_replaces_old_version(self, tmp_path):
+        """When an older version exists, its rows should be removed after indexing."""
+        old_zim = self._make_zim(tmp_path, "devdocs_en_python_2025-01.zim")
+        new_zim = self._make_zim(tmp_path, "devdocs_en_python_2026-01.zim")
+        lib_xml = self._make_library_xml(tmp_path, [old_zim.name])
+        db_path = tmp_path / "idx.sqlite"
+
+        # Pre-index old content
+        conn = prepare_database(db_path, reset=True)
+        conn.execute(
+            "INSERT INTO documents (title, content, zim_name, namespace, url) "
+            "VALUES ('Old', 'old content', 'devdocs_en_python_2025-01', 'A', 'old_page')"
+        )
+        docid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute(
+            "INSERT INTO metadata (docid, zim_path) VALUES (?, ?)",
+            (docid, str(old_zim)),
+        )
+        conn.commit()
+        conn.close()
+
+        fake_articles = [
+            {"namespace": "A", "url": "new1", "title": "New Page", "content": "New content"},
+        ]
+
+        with (
+            patch("offline_search.updater.kiwix_manage_add", return_value=True),
+            patch("offline_search.updater.kiwix_manage_remove", return_value=True),
+            patch("offline_search.updater.restart_kiwix_server", return_value=True),
+            patch("offline_search.indexer.iter_articles", return_value=fake_articles),
+        ):
+            result = ingest_zim(
+                new_zim, library_xml=lib_xml, db_path=db_path, restart_kiwix=False,
+            )
+
+        assert result.success is True
+        assert result.articles_indexed == 1
+        assert result.articles_removed == 1
+        assert result.replaced is not None
+        assert result.replaced.base_name == "devdocs_en_python"
+
+        # Verify: only new content remains
+        import sqlite3
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert count == 1
+        title = conn.execute("SELECT title FROM documents").fetchone()[0]
+        assert title == "New Page"
+        conn.close()
+
+    def test_old_content_serves_during_indexing(self, tmp_path):
+        """During indexing, both old and new rows coexist in the database."""
+        old_zim = self._make_zim(tmp_path, "wiki_en_2025-01.zim")
+        new_zim = self._make_zim(tmp_path, "wiki_en_2026-01.zim")
+        lib_xml = self._make_library_xml(tmp_path, [old_zim.name])
+        db_path = tmp_path / "idx.sqlite"
+
+        # Pre-index old content
+        conn = prepare_database(db_path, reset=True)
+        conn.execute(
+            "INSERT INTO documents (title, content, zim_name, namespace, url) "
+            "VALUES ('Old Article', 'old', 'wiki_en_2025-01', 'A', 'old')"
+        )
+        docid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute(
+            "INSERT INTO metadata (docid, zim_path) VALUES (?, ?)",
+            (docid, str(old_zim)),
+        )
+        conn.commit()
+
+        coexistence_verified = False
+
+        original_index_zim = __import__("offline_search.indexer", fromlist=["index_zim"]).index_zim
+
+        def spy_index_zim(conn, zim_path, zim_name, **kwargs):
+            """During indexing, check that old content is still present."""
+            nonlocal coexistence_verified
+            # Insert a new row to simulate indexing
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO documents (title, content, zim_name, namespace, url) "
+                "VALUES ('New Article', 'new', ?, 'A', 'new')",
+                (zim_name,),
+            )
+            new_docid = cur.lastrowid
+            cur.execute(
+                "INSERT INTO metadata (docid, zim_path) VALUES (?, ?)",
+                (new_docid, str(zim_path)),
+            )
+            conn.commit()
+            # Both old and new should be present
+            count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+            coexistence_verified = count == 2
+            return 1
+
+        conn.close()
+
+        with (
+            patch("offline_search.updater.kiwix_manage_add", return_value=True),
+            patch("offline_search.updater.kiwix_manage_remove", return_value=True),
+            patch("offline_search.updater.restart_kiwix_server", return_value=True),
+            patch("offline_search.updater.index_zim", side_effect=spy_index_zim),
+        ):
+            result = ingest_zim(
+                new_zim, library_xml=lib_xml, db_path=db_path, restart_kiwix=False,
+            )
+
+        assert result.success is True
+        assert coexistence_verified, "Old and new content should coexist during indexing"
+
+    def test_invalid_zim_rejected(self, tmp_path):
+        """Invalid ZIM files should be rejected with an error."""
+        bad = tmp_path / "bad_2025-01.zim"
+        bad.write_bytes(b"\x00" * 100)
+
+        result = ingest_zim(bad, db_path=tmp_path / "idx.sqlite")
+        assert result.success is False
+        assert any("Invalid ZIM" in e for e in result.errors)
+
+    def test_unparseable_version_rejected(self, tmp_path):
+        """ZIM files without a parseable version should be rejected."""
+        zim = tmp_path / "noversion.zim"
+        zim.write_bytes(ZIM_MAGIC + b"\x00" * 100)
+
+        result = ingest_zim(zim, db_path=tmp_path / "idx.sqlite")
+        assert result.success is False
+        assert any("Cannot parse version" in e for e in result.errors)
+
+    def test_old_file_deleted_when_flag_set(self, tmp_path):
+        """When delete_old=True, the replaced ZIM file should be removed from disk."""
+        old_zim = self._make_zim(tmp_path, "test_en_2025-01.zim")
+        new_zim = self._make_zim(tmp_path, "test_en_2026-01.zim")
+        lib_xml = self._make_library_xml(tmp_path, [old_zim.name])
+        db_path = tmp_path / "idx.sqlite"
+
+        # Pre-index old
+        conn = prepare_database(db_path, reset=True)
+        conn.execute(
+            "INSERT INTO documents (title, content, zim_name, namespace, url) "
+            "VALUES ('Old', 'c', 'test_en_2025-01', 'A', 'old')"
+        )
+        docid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute("INSERT INTO metadata (docid, zim_path) VALUES (?, ?)", (docid, str(old_zim)))
+        conn.commit()
+        conn.close()
+
+        with (
+            patch("offline_search.updater.kiwix_manage_add", return_value=True),
+            patch("offline_search.updater.kiwix_manage_remove", return_value=True),
+            patch("offline_search.updater.restart_kiwix_server", return_value=True),
+            patch("offline_search.indexer.iter_articles", return_value=[]),
+        ):
+            result = ingest_zim(
+                new_zim, library_xml=lib_xml, db_path=db_path,
+                delete_old=True, restart_kiwix=False,
+            )
+
+        assert result.success is True
+        assert not old_zim.exists(), "Old ZIM file should be deleted"
+
+
+# ---------------------------------------------------------------------------
+# Manifest export
+# ---------------------------------------------------------------------------
+
+class TestExportManifest:
+    def test_manifest_round_trip(self, tmp_path):
+        """Manifest export should produce a JSON-serialisable list."""
+        lib_xml = tmp_path / "library.xml"
+        lib_xml.write_text(
+            '<?xml version="1.0"?><library>'
+            '<book path="devdocs_en_python_2026-01.zim"/>'
+            '</library>',
+            encoding="utf-8",
+        )
+
+        manifest = export_manifest(lib_xml)
+        assert isinstance(manifest, list)
+        assert len(manifest) == 1
+        assert manifest[0]["base_name"] == "devdocs_en_python"
+        assert manifest[0]["version"] == "2026-01"


### PR DESCRIPTION
## Summary
- **ZIM magic bytes**: Fixed `ZIM_MAGIC` constant from `b"\x44\x49\x4d\x04"` (`DIM\x04`) to `b"ZIM\x04"`, and corrected the corresponding test data in `test_server.py`
- **Catalog pagination**: The catalog updater was fetching the Kiwix OPDS catalog without query parameters, receiving only the first page (~50 results). ZIMs that fell off the first page were silently reported as up-to-date. Added `check_updates_for_installed()` which queries the catalog individually per installed ZIM, ensuring all updates are found regardless of catalog pagination

## Test plan
- [x] Existing tests pass (200/200, the previously failing `test_accepts_valid_upload` now passes)
- [x] New tests verify updates are found for all installed ZIMs even when not on the first catalog page
- [x] New tests verify mixed scenarios (some ZIMs current, some outdated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)